### PR TITLE
Shorten code

### DIFF
--- a/stocker/error.py
+++ b/stocker/error.py
@@ -9,9 +9,6 @@ def get(true_values, predicted_values, error_method='mape'): # function to calcu
         # calculate the mean absolute percentage error
         error = (abs((true_values - predicted_values) / true_values).sum() / len(true_values)) * 100
         error = round(error, 3)
-
-    if error_method == 'mse':
+    elif error_method == 'mse':
         # calculate the mean squared error
-        error = round(math.sqrt(mean_squared_error(true_values, predicted_values)), 3)
-
-    return error
+        return (error := round(math.sqrt(mean_squared_error(true_values, predicted_values)), 3))


### PR DESCRIPTION
This will shorten the code and change the second if statement to an elif statement and make it part of the first if statement. I also shortened the end by using the walrus operator to set the error value within the return statement. Please keep in mind that this can only be used on Python 3.8 and above if implemented. If this is not in the best interests of the repository, please feel free to discard my pull request.