### PR TITLE
Implement Walrus Operator

### DIFF
--- a/stocker/get_data.py
+++ b/stocker/get_data.py
@@ -15,17 +15,13 @@ def main(stock, years=1):  # function to get data from Yahoo Finance
 
 def company_name(stock):  # function to get the company's name from the stock
     url = "http://d.yimg.com/autoc.finance.yahoo.com/autoc?query={}&region=1&lang=en".format(stock)  # source
-    company = requests.get(url).json()['ResultSet']['Result'][0]['name']   # saving the name as 'company'
-
-    return company
+    return (company := requests.get(url).json()['ResultSet']['Result'][0]['name'])   # saving the name as 'company'
 
 
 def get_interest(company, timeframe):  #  base function to get 'interest' from Google Trends
     pytrend = TrendReq()  # accessing to Google Trends using pytrends package
     pytrend.build_payload(kw_list=[company], timeframe=timeframe)  # finding interest for 'company' during 'timeframe'
-    result = pytrend.interest_over_time().drop('isPartial', axis=1)  # saving the 'interest' values
-
-    return result
+    return (result := pytrend.interest_over_time().drop('isPartial', axis=1))  # saving the 'interest' values
 
 
 def add_interest(df, company, years=1):  # main function to get 'interest' from Google Trends
@@ -124,9 +120,7 @@ def total(stock, years=1, interest=False, wiki_views=False, indicators=False, pe
         df = add_r(df, period)  # generating %R column.
         df = add_rsi(df, period)  # generating RSI column.
 
-    df = df.dropna()   # drop rows with missing data
-
-    return df
+    return (df := df.dropna())   # drop rows with missing data
 
 
 def correlation(stock, years=1, interest=False, wiki_views=False, indicators=False, period=14, complete=True, limit=0.5):


### PR DESCRIPTION
Note: This will only work on Python versions 3.8 and above. If you do not intend on using this code on those versions, please discard this pull request.
This will do the same thing as before, just in a shorter fashion. The walrus operator allows you to set values inside of expressions.
Example:
print(n := 5)
^ This would print 5 to the console window and set n equal to it